### PR TITLE
Refine Death Stranding vertex stream parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,66 @@
 # HZDMeshTool
-Import/Export meshes from Horizon Zero Dawn's .core format
 
-## Download
-https://github.com/AlexP0/HZDMeshTool/releases
+Blender add-on for exploring and modifying meshes built on Guerrilla Games' Decima engine. The tool began as an importer/exporter for **Horizon Zero Dawn** and now bundles experimental research toward **Death Stranding** support, including data-mining utilities and format notes.
 
-## Installation
-- In Blender open the User Preferences
-- Go in the Add-ons tab and click Install...
-- Select the HZDMeshTool.zip file
-- Enable the addon
+## Feature status
 
-## Usage
-### 1 - Go to Scene Properties tab
+| Area | Status | Notes |
+| --- | --- | --- |
+| Horizon Zero Dawn skeletal meshes | ✅ Stable | Import/export of `.core`/`.stream` pairs through the Blender add-on. Original workflows remain intact. |
+| Death Stranding mesh import | ⚠️ In progress | Vertex stream metadata is parsed, but chunked buffers are not yet expanded into Blender meshes. |
+| Death Stranding mesh export | ❌ Blocked | Export raises a `DeathStrandingExportError` until shared stream repacking is implemented. |
+| Tooling | ✅ Stable | `tools/analyze_ds_core.py` dumps block/stream metadata to aid reverse-engineering. |
 
-### 2 - As of 1.3 you have two ways of importing meshes
-### **2A** - **Extract the files directly from the game.**
-- - **A-1 Set the Workspace Path**
->This is the path where assets will be extracted from the game (in a file tree)
-- - **A-2 Set the Game Path** 
->This is the path to the **folder** where HorizonZeroDawn.exe is located
-- - **A-3 Set the Asset Path** 
->This is the archive path to a skeletal mesh (e.g.,models/characters/humans/aloy/animation/parts/aloy_ct_a_lx.core)
-- - **A-4 Click Extract** 
->This will extract the mesh .core and .stream along with the appropriate skeleton .core **directly** from the game files. 
-It will also auto-input the paths in the Mesh Core and Skeleton Core fields and will auto-click Search Data so you're ready for import. 
-(In general the tool will never extract over existing files, delete the files manually if you want to extract them again)
+## Repository layout
 
-### **2B** - **Use already extract files (from ProjectDecima or other extraction tool)**
-- - **Input a file in Mesh Core and Skeleton Core.**
->Must be .core files, the associated .stream must be in the same directory and have the same name. 
-    The skeleton must be the one referenced in by the mesh.
+- `__init__.py` – Blender add-on entry point containing the Horizon toolchain plus Death Stranding guards and stream parsing hooks.
+- `decima/` – Supporting modules, including Death Stranding helpers (`ds_vertex_streams.py`, `ds_export.py`) and shared typing utilities.
+- `docs/death_stranding_analysis.md` – Notes captured while comparing Death Stranding assets to the legacy Horizon format.
+- `tools/analyze_ds_core.py` – Standalone CLI for inspecting `.core` meshes and enumerating vertex/index references.
+- `DSfiles/` – Sample Death Stranding assets used for analysis and testing.
 
-- - **Click Search Data**
->The tool will search for and display a list of mesh parts found in the .core file.
-    Meshes are part of either a LOD Object (contains 1 LOD with multiple elements) or a LOD Group (contains multiple LODs)
-    Lowest level LODs aren't handled yet because they are stored directly in the .core
-    Mesh parts with a warning sign are not safe to export yet.
+## Installation (Blender add-on)
 
-### 3 - Click Import icon next to one of the mesh parts in the LOD Objects or LOD Groups sub-panels
->A mesh will be created and placed in organized collection. The tool will search for existing skeleton based on the armature data number, it will import one from the skeleton .core if not found. You can also click the button named "Import" to import the entire LOD. Take note that some mesh have multiple UVs or Vertex Color channels.
+1. Download the repository or grab a packaged `.zip` from your preferred distribution method.
+2. In Blender, open **Edit → Preferences… → Add-ons** and choose **Install…**
+3. Select the `HZDMeshTool.zip` archive (or the cloned repository folder) and enable **HZD Mesh Tool**.
+4. A new **HZD Mesh Tool** panel appears under **Scene Properties**.
 
-#### 3A - Texture Extract and Material Creation
->If you setup Game Path and Workspace Path in set 2A, you can enable the Extract Texture checkbox. If enabled, the tool will extract every textures used by the imported mesh part to the Workspace directory. You can click the checkered icon on next to the mesh import button to see the textures used.
->
->Extracting textures will also cause the tool to create a material (if it doesn't already exist) and place the textures in it.
->Texture Sets will be built into Node Groups with outputs coresponding to the in-game usage of the texture or it's RGBA channels.
->No connection will be made to the shader node, I have no way of knowing which texture goes where yet.
-    
+## Working with Horizon Zero Dawn assets
 
-### 4 - Do your edits  
->You can edit the mesh however you want, but:
-    -You must keep the Vertex Group order intact
-    -You must have the same amount of UVs/vColor channels as was imported
-    -Modifications to the skeleton are not considered
-    
-### 5 - Click Export Button (to export an entire lod) or the export icon for a singular mesh part.
-    
->The original files will be overwritten with the new data.
-    The tool will export the Object that has the same name as the mesh part (e.i.: "0_Eyelashes")
-    The number after the name is the vertex count of the original mesh, it is not relevant to export. 
-    (only to give an idea of the size of the mesh data on import)
-    Again: Mesh parts with a warning sign are not safe to export yet.
-    
-### 6 - Modifying LOD Distances.
+The legacy workflow remains unchanged:
 
->You may also modify the distances (in meters) at which the lod will appear in game.
-    Click Save LOD Distances button to save them on the file.
+1. Go to **Scene Properties → HZD Mesh Tool**.
+2. Either extract directly from your game install (set *Workspace Path*, *Game Path*, *Asset Path* and click **Extract**) or point the tool at already-extracted `.core` files.
+3. Click **Search Data** to list the LOD objects and mesh parts found inside the mesh `.core` file.
+4. Use the import icons to bring individual mesh parts (or the **Import** button for a full LOD) into Blender. Skeletons are auto-imported on demand.
+5. Edit the mesh while preserving vertex group order, UV/VColor channel counts, and skeleton structure.
+6. Use the export icons (or **Export** button) to overwrite the corresponding `.core`/`.stream` pair. LOD distances can also be edited and saved from the panel.
+
+Texture extraction, material creation, and node-group helpers continue to function when the **Extract Textures** option is enabled and the workspace is configured.
+
+## Experimental Death Stranding support
+
+Death Stranding stores vertex data as mesh-wide stream sets with shared chunk tables. The add-on now recognises these resources and preserves their metadata during parsing, but Blender import/export is still incomplete:
+
+- Import currently stops after recording the `VertexStreamSet` descriptors. Vertex buffers are not yet sliced per primitive, so meshes will not appear in Blender.
+- Export short-circuits with a clear error because chunked stream repacking has not been written.
+- The `tools/analyze_ds_core.py` utility can be used to inspect `.core` files, study block relationships, and collect GUIDs for future implementation work:
+  ```bash
+  python tools/analyze_ds_core.py DSfiles/mesh_test.core --limit 40
+  ```
+
+Refer to `docs/death_stranding_analysis.md` for the observed stream layout, block identifiers, and differences from Horizon Zero Dawn.
+
+## Remaining work
+
+- [ ] Slice Death Stranding `VertexStreamSet` buffers into `StreamData` objects so meshes can be instantiated in Blender.
+- [ ] Rebuild Death Stranding chunk tables during export, packing vertex and index data per mesh before writing `.stream` files.
+- [ ] Audit index buffer handling to confirm whether Death Stranding also shares chunked indices across primitives.
+- [ ] Extend automated tests/dev workflows to cover Death Stranding parsing once geometry import succeeds.
+- [ ] Document any additional Decima titles or format variations encountered during development.
+
+## Contributing
+
+Pull requests and research findings are welcome. Please include reproduction steps or command examples when reporting Death Stranding issues so the community can iterate on the format support.
+

--- a/__init__.py
+++ b/__init__.py
@@ -25,6 +25,9 @@ import mathutils
 import math
 import operator
 
+from .decima.ds_vertex_streams import VertexStreamSet as DSVertexStreamSet
+from .decima.ds_export import export_death_stranding_mesh, DeathStrandingExportError
+
 from sys import platform
 import ctypes
 from ctypes import c_size_t, c_char_p, c_int32
@@ -2169,6 +2172,12 @@ def ExportMesh(isLodMesh, resIndex, meshIndex, primIndex):
     stream = core + ".stream"
 
     vb: VertexArrayResource = prim.vertexBlock
+    if getattr(vb, "variant_name", None) == "DS":
+        try:
+            export_death_stranding_mesh(mesh, prim, primIndex, meshName)
+        except DeathStrandingExportError as exc:
+            print("Death Stranding export is not implemented: %s" % exc)
+        return
     vs: StreamData = vb.vertexStream
     ns: StreamData = vb.normalsStream
     us: StreamData = vb.uvStream
@@ -2422,22 +2431,62 @@ class Asset:
         self.skeletonPath = "" #path to skeleton asset (start with models/ end with .core).
 
 
-BlockIDs = {"RegularSkinnedMeshResource" : 10982056603708398958,
-        "VertexArrayResource" : 13522917709279820436,
-        "SkinnedMeshBoneBindings" : 232082505300933932,
-        "SkinnedMeshBoneBoundingBoxes" : 1425406424293942754,
-        "RegularSkinnedMeshResourceSkinInfo" : 4980347625154103665,
-        "RenderingPrimitiveResource" : 17523037150162385132,
-        "IndexArrayResource" : 12198706699739407665,
-        "RenderEffectResource" : 12029122079492233037,
-        "LodMeshResource" : 6871768592993170868,
-        "ShaderResource" : 5215210673454096253, #was 5215210673454096253 5561636305660569489
-        "TextureResource" : 17501462827539052646,
-        "MultiMeshResource" : 7022335006738406101,
-        "DataBufferResource" : 10234768860597628846,
-        "StaticMeshResource" : 17037430323200133752,
-        "SKDTreeResource" : 13505794420212475061,
-        "SkeletonHelpers" : 6306064744810253771
+class BlockIDSet:
+    def __init__(self, name, variants=None, **extra_variants):
+        self.name = name
+        self._variants = {}
+        if variants is not None:
+            if isinstance(variants, dict):
+                self._variants.update(variants)
+            else:
+                raise TypeError("variants must be provided as a mapping of variant name to ID")
+        if extra_variants:
+            self._variants.update(extra_variants)
+        if not self._variants:
+            raise ValueError(f"BlockIDSet '{name}' must define at least one variant")
+
+    def __contains__(self, value):
+        return value in self._variants.values()
+
+    def __iter__(self):
+        return iter(self._variants.values())
+
+    def __getitem__(self, variant_name):
+        return self._variants[variant_name]
+
+    def items(self):
+        return self._variants.items()
+
+    def variants(self):
+        return dict(self._variants)
+
+    def as_set(self):
+        return set(self._variants.values())
+
+    def variant_for(self, block_id):
+        for variant_name, variant_id in self._variants.items():
+            if variant_id == block_id:
+                return variant_name
+        return None
+
+
+BlockIDs = {
+        "RegularSkinnedMeshResource" : BlockIDSet("RegularSkinnedMeshResource", HZD=10982056603708398958),
+        "VertexArrayResource" : BlockIDSet("VertexArrayResource", HZD=13522917709279820436, DS=0x3AC29A123FAABAB4),
+        "SkinnedMeshBoneBindings" : BlockIDSet("SkinnedMeshBoneBindings", HZD=232082505300933932),
+        "SkinnedMeshBoneBoundingBoxes" : BlockIDSet("SkinnedMeshBoneBoundingBoxes", HZD=1425406424293942754),
+        "RegularSkinnedMeshResourceSkinInfo" : BlockIDSet("RegularSkinnedMeshResourceSkinInfo", HZD=4980347625154103665),
+        "RenderingPrimitiveResource" : BlockIDSet("RenderingPrimitiveResource", HZD=17523037150162385132, DS=0xEE49D93DA4C1F4B8),
+        "IndexArrayResource" : BlockIDSet("IndexArrayResource", HZD=12198706699739407665),
+        "RenderEffectResource" : BlockIDSet("RenderEffectResource", HZD=12029122079492233037),
+        "LodMeshResource" : BlockIDSet("LodMeshResource", HZD=6871768592993170868),
+        "ShaderResource" : BlockIDSet("ShaderResource", HZD=5215210673454096253), #was 5215210673454096253 5561636305660569489
+        "TextureResource" : BlockIDSet("TextureResource", HZD=17501462827539052646),
+        "MultiMeshResource" : BlockIDSet("MultiMeshResource", HZD=7022335006738406101),
+        "DataBufferResource" : BlockIDSet("DataBufferResource", HZD=10234768860597628846, DS=0x0B0D03C7E087F38E),
+        "StaticMeshResource" : BlockIDSet("StaticMeshResource", HZD=17037430323200133752),
+        "SKDTreeResource" : BlockIDSet("SKDTreeResource", HZD=13505794420212475061),
+        "SkeletonHelpers" : BlockIDSet("SkeletonHelpers", HZD=6306064744810253771)
             }
 asset = Asset()
 
@@ -2446,10 +2495,39 @@ class DataBlock:
         r = ByteReader
 
         self.expectedID = expectedID
+        self.expected_ids = None
+        self.variant_name = None
+        self.block_type = None
+        variant_lookup = None
+        if isinstance(expectedID, BlockIDSet):
+            variant_lookup = expectedID
+            self.block_type = expectedID.name
+            self.expected_ids = expectedID.as_set()
+        elif expectedID not in (0, None):
+            if isinstance(expectedID, dict):
+                variant_lookup = expectedID
+                self.expected_ids = set(expectedID.values())
+            elif isinstance(expectedID, (set, tuple, list)):
+                self.expected_ids = set(expectedID)
+            else:
+                self.expected_ids = {expectedID}
         self.ID = r.uint64(f)
-        if expectedID != 0:
-            if self.ID != self.expectedID:
-                raise Exception("%s -- offset %d  --  Invalid Block ID: got %d expected %d"%(self.__class__.__name__,f.tell()-8,self.ID ,self.expectedID))
+        if self.expected_ids:
+            if self.ID not in self.expected_ids:
+                expected_desc = ", ".join(f"0x{id_value:016X}" for id_value in sorted(self.expected_ids))
+                raise Exception("%s -- offset %d  --  Invalid Block ID: got 0x%016X expected one of %s" % (
+                    self.__class__.__name__,
+                    f.tell()-8,
+                    self.ID,
+                    expected_desc))
+            if variant_lookup:
+                if isinstance(variant_lookup, BlockIDSet):
+                    self.variant_name = variant_lookup.variant_for(self.ID)
+                else:
+                    for name, variant_id in variant_lookup.items():
+                        if variant_id == self.ID:
+                            self.variant_name = name
+                            break
         self.size = r.int32(f)
         self.blockStartOffset = f.tell()
         self.guid = r.guid(f)
@@ -2951,6 +3029,19 @@ class VertexArrayResource(DataBlock):
         super().__init__(f,BlockIDs["VertexArrayResource"],expectedGuid)
         r = ByteReader
         self.posVCount = f.tell()
+        if self.variant_name == "DS":
+            self.streamRefCount = 0
+            self.inStream = True
+            self.vertexStream = None
+            self.normalsStream = None
+            self.uvStream = None
+            block_end = self.blockStartOffset + self.size
+            self.ds_vertex_set = DSVertexStreamSet.parse(r, f, block_end=block_end)
+            self.vertexCount = self.ds_vertex_set.vertex_count
+            self.streamDescriptors = self.ds_vertex_set.streams
+            self.EndBlock(f)
+            return
+
         self.vertexCount = r.uint32(f)
         self.streamRefCount = r.uint32(f)
         self.inStream = r.bool(f)
@@ -2969,6 +3060,14 @@ class VertexArrayResource(DataBlock):
     def __str__(self):
         s = "\n--VertexArrayResource"
         s += "\n'''Vertex Count = %d  |  inStream = %s"%(self.vertexCount,str(self.inStream))
+        if hasattr(self, "ds_vertex_set"):
+            s += "\n----DS Stream Set with %d descriptors" % len(self.streamDescriptors)
+            for index, descriptor in enumerate(self.streamDescriptors):
+                s += "\n------Stream %d header: %s" % (index, descriptor.header)
+                s += "\n------Stream %d chunk GUID: %s" % (index, descriptor.chunk_guid)
+                if descriptor.tail:
+                    s += "\n------Stream %d tail: %s" % (index, descriptor.tail)
+            return s
         s += "\n----VertexStream " + self.vertexStream.__str__()
         if self.normalsStream:
             s += "\n----NormalsStream " + self.normalsStream.__str__()
@@ -3352,13 +3451,13 @@ def ReadCoreFile():
             ID = r.uint64(f)
             f.seek(-8,1)
             # print(ID)
-            if ID == BlockIDs["LodMeshResource"]: # LodMeshResource
+            if ID in BlockIDs["LodMeshResource"]: # LodMeshResource
                 asset.LodMeshResources.append(LodMeshResource(f))
-            elif ID == BlockIDs["MultiMeshResource"]: # MultiMeshResource
+            elif ID in BlockIDs["MultiMeshResource"]: # MultiMeshResource
                 asset.MultiMeshResources.append(MultiMeshResource(f))
-            elif ID == BlockIDs["RegularSkinnedMeshResource"]: # RegularSkinnedMeshResource
+            elif ID in BlockIDs["RegularSkinnedMeshResource"]: # RegularSkinnedMeshResource
                 asset.RegularSkinnedMeshResources.append(RegularSkinnedMeshResource(f))
-            elif ID == BlockIDs["StaticMeshResource"]: # StaticMeshResource
+            elif ID in BlockIDs["StaticMeshResource"]: # StaticMeshResource
                 asset.StaticMeshResources.append(StaticMeshResource(f))
             else:
                 raise Exception("This file is not supported.",ID)

--- a/decima/__init__.py
+++ b/decima/__init__.py
@@ -1,0 +1,1 @@
+"""Helpers for parsing Decima engine data."""

--- a/decima/ds_export.py
+++ b/decima/ds_export.py
@@ -1,0 +1,104 @@
+"""Utilities for exporting Death Stranding mesh streams.
+
+At the moment the toolkit can parse the shared ``VertexStreamSet`` blocks that
+Death Stranding uses, but the exporter still operates on the older Horizon
+layout.  The helpers in this module centralise the logic that groups
+primitives by their shared stream set so the main exporter can short-circuit
+before attempting to treat them like Horizon meshes.
+
+The actual stream repacking work remains unimplemented – the format requires
+rebuilding the per-mesh chunk table before any bytes can be written back to
+disk.  Raising a dedicated exception keeps the failure explicit and avoids the
+generic ``AttributeError`` that Blender would otherwise surface when the
+Horizon codepath touches ``vertexStream`` on a Death Stranding primitive.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+class DeathStrandingExportError(RuntimeError):
+    """Raised when exporting a Death Stranding mesh is not yet supported."""
+
+
+@dataclass(frozen=True)
+class PrimitiveBinding:
+    """Links a mesh resource primitive to its object name in Blender.
+
+    The Horizon exporter addresses objects via the naming scheme
+    ``"{primitive_index}_{mesh_name}"``.  Grouping the primitives that share a
+    ``VertexStreamSet`` allows future work to repack the shared streams instead
+    of rewriting them per primitive as Horizon does.
+    """
+
+    primitive_index: int
+    mesh_name: str
+
+    @property
+    def object_name(self) -> str:
+        return f"{self.primitive_index}_{self.mesh_name}"
+
+
+def collect_primitives_sharing_vertex_set(
+    mesh_resource,
+    vertex_guid,
+    mesh_name: str,
+) -> List[PrimitiveBinding]:
+    """Return the mesh primitives that reference ``vertex_guid``.
+
+    Parameters
+    ----------
+    mesh_resource:
+        Either ``RegularSkinnedMeshResource`` or ``StaticMeshResource`` as
+        parsed by the add-on.  The object is assumed to expose a ``primitives``
+        attribute containing ``RenderingPrimitiveResource`` instances, each of
+        which provides a ``vertexRef`` reference with a ``guid`` attribute.
+    vertex_guid:
+        The UUID shared by the ``VertexStreamSet`` block.
+    mesh_name:
+        Used to reproduce Blender's export object naming pattern.
+    """
+
+    bindings: List[PrimitiveBinding] = []
+    primitives = getattr(mesh_resource, "primitives", [])
+    for index, primitive in enumerate(primitives):
+        reference = getattr(primitive, "vertexRef", None)
+        if reference is None:
+            continue
+        if getattr(reference, "guid", None) == vertex_guid:
+            bindings.append(PrimitiveBinding(index, mesh_name))
+    return bindings
+
+
+def export_death_stranding_mesh(
+    mesh_resource,
+    primitive,
+    primitive_index: int,
+    mesh_name: str,
+) -> None:
+    """Entry point used by :func:`ExportMesh` when a DS primitive is detected.
+
+    The routine currently raises :class:`DeathStrandingExportError` to make it
+    explicit to callers – and therefore to Blender users – that exporting a
+    Death Stranding mesh still requires implementing the chunked stream
+    repacker.  Returning ``None`` here would silently fall back to the Horizon
+    codepath, which would in turn corrupt the file by writing a per-primitive
+    stream layout.
+    """
+
+    vertex_guid = getattr(getattr(primitive, "vertexRef", None), "guid", None)
+    if vertex_guid is None:
+        raise DeathStrandingExportError(
+            "Primitive does not expose a vertex stream reference; cannot export"
+        )
+
+    bindings = collect_primitives_sharing_vertex_set(mesh_resource, vertex_guid, mesh_name)
+    referenced_objects = [binding.object_name for binding in bindings]
+
+    raise DeathStrandingExportError(
+        "Death Stranding export requires repacking shared vertex/index streams "
+        "(referenced Blender objects: %s)" % ", ".join(referenced_objects)
+    )
+

--- a/decima/ds_vertex_streams.py
+++ b/decima/ds_vertex_streams.py
@@ -1,0 +1,77 @@
+"""Death Stranding-specific stream parsing helpers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Sequence, Tuple
+from uuid import UUID
+
+from .typing import ByteReaderProtocol
+
+
+@dataclass
+class StreamDescriptor:
+    """Metadata extracted from a single Death Stranding vertex stream."""
+
+    header: Tuple[int, ...]
+    chunk_guid: UUID
+    tail: Tuple[int, ...]
+
+
+@dataclass
+class VertexStreamSet:
+    """Structured representation of a ``VertexStreamSet`` block."""
+
+    vertex_count: int
+    stream_count: int
+    header_tail: Tuple[int, int]
+    streams: List[StreamDescriptor]
+    trailing: bytes
+
+    @classmethod
+    def _read_guid(cls, words: Sequence[int]) -> UUID:
+        return UUID(bytes_le=b"".join(word.to_bytes(4, "little") for word in words))
+
+    @classmethod
+    def parse(cls, reader: ByteReaderProtocol, f, *, block_end: int) -> "VertexStreamSet":
+        """Parse a Death Stranding ``VertexStreamSet``.
+
+        Parameters
+        ----------
+        reader:
+            Adapter providing ``uint32`` for little-endian parsing.
+        f:
+            Binary file object currently positioned at the start of the block
+            payload (just after the GUID written by :class:`DataBlock`).
+        block_end:
+            Absolute file offset marking the end of the block so the parser can
+            capture any trailing padding bytes without depending on the caller.
+        """
+
+        vertex_count = reader.uint32(f)
+        stream_count = reader.uint32(f)
+        field2 = reader.uint32(f)
+        field3 = reader.uint32(f)
+
+        streams: List[StreamDescriptor] = []
+        for index in range(stream_count):
+            header_length = 6 if index == 0 else 4
+            header = tuple(reader.uint32(f) for _ in range(header_length))
+            guid_words = tuple(reader.uint32(f) for _ in range(4))
+            chunk_guid = cls._read_guid(guid_words)
+            tail: Tuple[int, ...]
+            if index == 0:
+                tail = (reader.uint32(f), reader.uint32(f))
+            else:
+                tail = ()
+            streams.append(StreamDescriptor(header=header, chunk_guid=chunk_guid, tail=tail))
+
+        remaining = max(block_end - f.tell(), 0)
+        trailing = f.read(remaining) if remaining else b""
+
+        return cls(
+            vertex_count=vertex_count,
+            stream_count=stream_count,
+            header_tail=(field2, field3),
+            streams=streams,
+            trailing=trailing,
+        )

--- a/decima/typing.py
+++ b/decima/typing.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class ByteReaderProtocol(Protocol):
+    def uint32(self, f): ...  # pragma: no cover - protocol definition only

--- a/docs/death_stranding_analysis.md
+++ b/docs/death_stranding_analysis.md
@@ -1,0 +1,14 @@
+# Death Stranding Format Notes
+
+## Vertex stream layout in `mesh_test.dmf`
+- Primitive 0 uses three vertex buffer views with matching strides for position/weights (`stride = 28`), normals/tangents (`stride = 28`), and colour/UV (`stride = 8`).
+- Primitive 1 reuses the same pattern with different offsets.  All buffer views reference a single buffer (`ds/...file.stream`) with distinct offsets and sizes, meaning the mesh data is stored once per mesh and partitioned for each primitive.【F:DSfiles/mesh_test.dmf†L4623-L4662】【F:DSfiles/mesh_test.dmf†L4663-L4691】
+
+## Block identifiers discovered in `mesh_test.core`
+- Rendering primitives use block ID `0xEE49D93DA4C1F4B8` and reference vertex streams via GUIDs such as `71d9d23d-5e9f-b930-ab89-ef0525098768` and index streams via GUIDs like `4a8b7d12-47f7-8a3b-9d47-290596427690`.【F:tools/analyze_ds_core.py†L200-L229】【719378†L28-L34】
+- Vertex stream sets share block ID `0x3AC29A123FAABAB4` and expose three chunked streams per mesh (positions, normals/tangents, UV/colour).  The raw integer payload shows per-stream metadata followed by GUID links back to chunk tables, highlighting the difference from HZD's per-primitive streams.【F:tools/analyze_ds_core.py†L89-L157】【e1d068†L33-L43】
+- Chunk tables live in blocks with ID `0x0B0D03C7E087F38E`, confirming that Death Stranding groups stream data per mesh and references shared chunks across primitives/LODs.【F:tools/analyze_ds_core.py†L40-L78】【719378†L22-L26】
+
+## Observations
+- Death Stranding stores vertex data per mesh with shared chunk tables, while Horizon Zero Dawn stores separate vertex streams per primitive.  The `.dmf` buffer view definitions map directly onto the chunked layout exposed by the new block IDs.
+- To support Death Stranding we will need new parsing code that can interpret the `VertexStreamSet` blocks, resolve their chunk tables, and slice the shared buffer into primitive-specific ranges before handing data to Blender.

--- a/tools/analyze_ds_core.py
+++ b/tools/analyze_ds_core.py
@@ -1,0 +1,256 @@
+"""Utility to inspect Death Stranding .core files.
+
+The Horizon Zero Dawn mesh tool expects per-primitive vertex streams.  Death
+Stranding reorganises the same data into chunked streams that are shared by
+multiple primitives.  This helper performs a light-weight parse of a .core file
+so we can reason about the new layout without requiring Blender.
+"""
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import struct
+import uuid
+from pathlib import Path
+from typing import Dict, Iterator, List, Sequence, Tuple
+
+# Known block identifiers gathered from analysing mesh_test.core.  The Horizon
+# Zero Dawn tool uses a different numeric set, therefore the first step towards
+# supporting Death Stranding is to map the new IDs back to the conceptual
+# structures that the add-on expects.
+BLOCK_NAMES: Dict[int, str] = {
+    0x6319028A13556F1E: "DataBufferResource?",
+    0x36B88667B0A33134: "RegularSkinnedMeshResource",
+    0xE2A812418ABC2172: "SkinnedMeshBoneBindings",
+    0xBCE84D96052C041E: "SkinnedMeshBoneBoundingBoxes",
+    0x118378C2F191097A: "RegularSkinnedMeshResourceSkinInfo",
+    0xFE2843D4AAD255E7: "RenderEffectResource",
+    0x0B0D03C7E087F38E: "StreamChunkTable",
+    0x8EB29E71F97E460F: "CullInfo/LOD meta",
+    0xEE49D93DA4C1F4B8: "RenderingPrimitiveResource",
+    0x3AC29A123FAABAB4: "VertexStreamSet",
+    0x5FE633B37CEDBF84: "IndexStream",
+}
+
+
+def _read(fmt: str, data: memoryview, offset: int) -> Tuple[Tuple[int, ...], int]:
+    size = struct.calcsize(fmt)
+    values = struct.unpack_from(fmt, data, offset)
+    return values, offset + size
+
+
+@dataclasses.dataclass
+class Block:
+    offset: int
+    block_id: int
+    size: int
+    guid: uuid.UUID
+    payload: bytes
+
+    @property
+    def name(self) -> str:
+        return BLOCK_NAMES.get(self.block_id, f"0x{self.block_id:016X}")
+
+
+def iter_blocks(blob: bytes) -> Iterator[Block]:
+    offset = 0
+    view = memoryview(blob)
+    while offset + 28 <= len(blob):
+        (block_id,), offset = _read("<Q", view, offset)
+        (size,), offset = _read("<i", view, offset)
+        guid_bytes = bytes(view[offset : offset + 16])
+        offset += 16
+        payload = bytes(view[offset : offset + size - 16])
+        offset += size - 16
+        yield Block(
+            offset=offset - size,
+            block_id=block_id,
+            size=size,
+            guid=uuid.UUID(bytes_le=guid_bytes),
+            payload=payload,
+        )
+
+
+@dataclasses.dataclass
+class StreamDescriptor:
+    raw_fields: List[int]
+    guid: uuid.UUID
+    trailing: bytes
+
+    def describe(self) -> Dict[str, object]:
+        base: Dict[str, object] = {
+            "raw_fields": self.raw_fields,
+            "guid": str(self.guid),
+        }
+        if self.trailing:
+            base["trailing_bytes"] = self.trailing.hex()
+        return base
+
+
+@dataclasses.dataclass
+class VertexStreamSet:
+    vertex_count: int
+    stream_count: int
+    header_tail: Tuple[int, int]
+    streams: List[StreamDescriptor]
+    raw_values: List[int]
+
+    @classmethod
+    def parse(cls, block: Block) -> "VertexStreamSet":
+        payload = block.payload
+        head = memoryview(payload)
+        offset = 0
+        (vertex_count, stream_count, field2, field3), offset = _read(
+            "<IIII", head, offset
+        )
+        remaining = payload[offset:]
+        ints = list(
+            struct.unpack(
+                "<" + "I" * (len(remaining) // 4), remaining[: len(remaining) // 4 * 4]
+            )
+        )
+        tail = remaining[len(ints) * 4 :]
+        guid_words = ints[-stream_count * 4 :] if stream_count else []
+        raw_values = ints[: -stream_count * 4] if stream_count else ints
+        streams: List[StreamDescriptor] = []
+        for i in range(stream_count):
+            words = guid_words[i * 4 : (i + 1) * 4]
+            guid_bytes = b"".join(struct.pack("<I", value) for value in words)
+            streams.append(StreamDescriptor(raw_fields=[], guid=uuid.UUID(bytes_le=guid_bytes), trailing=b""))
+        if streams:
+            streams[-1].trailing = tail
+        vertex_set = cls(
+            vertex_count=vertex_count,
+            stream_count=stream_count,
+            header_tail=(field2, field3),
+            streams=streams,
+            raw_values=raw_values,
+        )
+        # Attach the raw integers to the first stream descriptor for debugging
+        # purposes so downstream tooling can inspect the per-stream metadata
+        # without guessing at the layout yet.
+        if vertex_set.streams:
+            vertex_set.streams[0].raw_fields = raw_values
+        return vertex_set
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "vertex_count": self.vertex_count,
+            "stream_count": self.stream_count,
+            "header_tail": self.header_tail,
+            "raw_values": self.raw_values,
+            "streams": [stream.describe() for stream in self.streams],
+        }
+
+
+@dataclasses.dataclass
+class IndexStream:
+    index_count: int
+    unknown: Tuple[int, int, int]
+    guid: uuid.UUID
+
+    @classmethod
+    def parse(cls, block: Block) -> "IndexStream":
+        data = memoryview(block.payload)
+        offset = 0
+        (index_count, field1, field2, field3), offset = _read("<IIII", data, offset)
+        guid_bytes = bytes(data[offset : offset + 16])
+        guid = uuid.UUID(bytes_le=guid_bytes)
+        return cls(index_count=index_count, unknown=(field1, field2, field3), guid=guid)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "index_count": self.index_count,
+            "unknown": self.unknown,
+            "guid": str(self.guid),
+        }
+
+
+@dataclasses.dataclass
+class PrimitiveSummary:
+    guid: uuid.UUID
+    vertex_ref: uuid.UUID
+    index_ref: uuid.UUID
+
+    @classmethod
+    def parse(cls, block: Block) -> "PrimitiveSummary":
+        data = memoryview(block.payload)
+        offset = 4  # skip flags
+        vertex_type = data[offset]
+        offset += 1
+        vertex_guid = uuid.UUID(bytes_le=bytes(data[offset : offset + 16]))
+        offset += 16
+        index_type = data[offset]
+        offset += 1
+        index_guid = uuid.UUID(bytes_le=bytes(data[offset : offset + 16]))
+        return cls(guid=block.guid, vertex_ref=vertex_guid, index_ref=index_guid)
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "primitive": str(self.guid),
+            "vertex_ref": str(self.vertex_ref),
+            "index_ref": str(self.index_ref),
+        }
+
+
+def summarise(path: Path) -> Dict[str, object]:
+    blob = path.read_bytes()
+    blocks = list(iter_blocks(blob))
+    summary: Dict[str, object] = {
+        "block_count": len(blocks),
+        "blocks": [],
+    }
+    primitives: List[Dict[str, str]] = []
+    vertex_sets: Dict[uuid.UUID, Dict[str, object]] = {}
+    index_sets: Dict[uuid.UUID, Dict[str, object]] = {}
+    for block in blocks:
+        entry = {
+            "offset": block.offset,
+            "id": f"0x{block.block_id:016X}",
+            "name": block.name,
+            "size": block.size,
+            "guid": str(block.guid),
+        }
+        if block.block_id == 0xEE49D93DA4C1F4B8:
+            primitive = PrimitiveSummary.parse(block)
+            entry["details"] = primitive.to_dict()
+            primitives.append(primitive.to_dict())
+        elif block.block_id == 0x3AC29A123FAABAB4:
+            vertex = VertexStreamSet.parse(block)
+            vertex_sets[block.guid] = vertex.to_dict()
+            entry["details"] = vertex.to_dict()
+        elif block.block_id == 0x5FE633B37CEDBF84:
+            index = IndexStream.parse(block)
+            index_sets[block.guid] = index.to_dict()
+            entry["details"] = index.to_dict()
+        summary["blocks"].append(entry)
+    summary["primitives"] = primitives
+    summary["vertex_sets"] = vertex_sets
+    summary["index_sets"] = index_sets
+    return summary
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("core", type=Path, help="Death Stranding .core file")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Limit the number of blocks displayed in the textual summary",
+    )
+    args = parser.parse_args()
+    data = summarise(args.core)
+    blocks: Sequence[Dict[str, object]] = data["blocks"]
+    limit = args.limit or len(blocks)
+    for block in blocks[:limit]:
+        print(f"{block['offset']:08x} {block['name']:>28} {block['size']:6d} {block['guid']}")
+        details = block.get("details")
+        if isinstance(details, dict):
+            for key, value in details.items():
+                print(f"    {key}: {value}")
+    print(f"Total blocks: {data['block_count']}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- restructure the Death Stranding VertexStreamSet parser to capture per-stream headers, chunk GUIDs, and trailing padding
- update VertexArrayResource to use the structured parser and surface the parsed stream metadata for debugging

## Testing
- python -m compileall decima/ds_vertex_streams.py __init__.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b81b9c8883299d95941b5c695c2e